### PR TITLE
Added default match case for distribution type, necessary to handle third-party types.

### DIFF
--- a/seahorse-workflow-executor/deeplang/src/main/scala/ai/deepsense/deeplang/doperables/dataframe/report/distribution/DistributionType.scala
+++ b/seahorse-workflow-executor/deeplang/src/main/scala/ai/deepsense/deeplang/doperables/dataframe/report/distribution/DistributionType.scala
@@ -27,5 +27,6 @@ private[distribution] object DistributionType extends Enumeration {
     case StringType | BooleanType => Discrete
     case BinaryType | _: ArrayType | _: MapType |
          _: StructType | _: ai.deepsense.sparkutils.Linalg.VectorUDT => NotApplicable
+    case _ => NotApplicable
   }
 }

--- a/seahorse-workflow-executor/deeplang/src/main/scala/ai/deepsense/deeplang/doperables/dataframe/report/distribution/DistributionType.scala
+++ b/seahorse-workflow-executor/deeplang/src/main/scala/ai/deepsense/deeplang/doperables/dataframe/report/distribution/DistributionType.scala
@@ -25,8 +25,6 @@ private[distribution] object DistributionType extends Enumeration {
   def forStructField(structField: StructField): DistributionType = structField.dataType match {
     case TimestampType | DateType | _: NumericType => Continuous
     case StringType | BooleanType => Discrete
-    case BinaryType | _: ArrayType | _: MapType |
-         _: StructType | _: ai.deepsense.sparkutils.Linalg.VectorUDT => NotApplicable
     case _ => NotApplicable
   }
 }


### PR DESCRIPTION
Add-on Spark packages such as RasterFrames (my project) and GeoMesa (geo-spatial vector types) add custom UDTs to Spark SQL. Without this fix, Seahorse throws an exception when encountering a schema with a non-standard type.

Signed-off-by: Simeon H.K. Fitch <fitch@astraea.io>