### PR TITLE
Fix for spark-submit redirection.  Now using correct logger name.

### DIFF
--- a/sessionmanager/src/main/scala/ai/deepsense/sessionmanager/service/sessionspawner/sparklauncher/outputintercepting/OutputInterceptorFactory.scala
+++ b/sessionmanager/src/main/scala/ai/deepsense/sessionmanager/service/sessionspawner/sparklauncher/outputintercepting/OutputInterceptorFactory.scala
@@ -67,7 +67,7 @@ class OutputInterceptorFactory @Inject()(
     new File(executorsLogDirectory).mkdirs()
 
     val childProcLoggerName = s"WE-app-${UUID.randomUUID()}"
-    val logger = Logger.getLogger(s"org.apache.spark.launcher.app.$childProcLoggerName")
+    val logger = Logger.getLogger(childProcLoggerName)
 
     val fileName = {
       val time = Calendar.getInstance().getTime()


### PR DESCRIPTION
This addresses issue #43