### PR TITLE
Created SPI for allowing SDK users to apply initialization steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ A good place to start using Seahorse is the [basic examples](http://seahorse.dee
 Note that in order to contribute to Seahorse you have to sign the
 [Contributor License Agreement](https://seahorse.deepsense.ai/licenses/cla).
 
+Before submitting a PR, please run the Scala style check:
+
+```console
+sbt scalastylebackend && (cd ./seahorse-workflow-executor && sbt scalastyle)
+```
+
 ### Running tests
 
 Initialize the submodules before running the tests:

--- a/seahorse-workflow-executor/commons/src/main/resources/META-INF/services/ai.deepsense.sparkutils.spi.SparkSessionInitializer
+++ b/seahorse-workflow-executor/commons/src/main/resources/META-INF/services/ai.deepsense.sparkutils.spi.SparkSessionInitializer
@@ -1,0 +1,1 @@
+ai.deepsense.commons.spark.sql.UserDefinedFunctions

--- a/seahorse-workflow-executor/commons/src/main/scala/ai/deepsense/commons/spark/sql/UserDefinedFunctions.scala
+++ b/seahorse-workflow-executor/commons/src/main/scala/ai/deepsense/commons/spark/sql/UserDefinedFunctions.scala
@@ -18,8 +18,13 @@ package ai.deepsense.commons.spark.sql
 
 import java.lang.{Double => JavaDouble}
 
-import org.apache.spark.sql.UDFRegistration
+import ai.deepsense.sparkutils.spi.SparkSessionInitializer
+import org.apache.spark.sql.{SparkSession, UDFRegistration}
 
+class UserDefinedFunctions() extends SparkSessionInitializer {
+  override def init(sparkSession: SparkSession): Unit =
+    UserDefinedFunctions.registerFunctions(sparkSession.udf)
+}
 /**
  * Holds user defined functions that can be injected to UDFRegistration
  * All the functions have to operate on java.lang.Double as input and output,
@@ -31,7 +36,7 @@ object UserDefinedFunctions extends Serializable {
   /**
    * Registers user defined function in given UDFRegistration
    */
-  def registerFunctions(udf: UDFRegistration): Unit = {
+  private def registerFunctions(udf: UDFRegistration): Unit = {
     udf.register("ABS", nullSafeSingleParamOp(math.abs))
     udf.register("EXP", nullSafeSingleParamOp(math.exp))
     udf.register("POW", nullSafeTwoParamOp(math.pow))

--- a/seahorse-workflow-executor/deeplang/src/it/resources/META-INF/services/ai.deepsense.sparkutils.spi.SparkSessionInitializer
+++ b/seahorse-workflow-executor/deeplang/src/it/resources/META-INF/services/ai.deepsense.sparkutils.spi.SparkSessionInitializer
@@ -1,0 +1,1 @@
+ai.deepsense.deeplang.TestUDFRegistrator

--- a/seahorse-workflow-executor/deeplang/src/it/scala/ai/deepsense/deeplang/DeeplangIntegTestSupport.scala
+++ b/seahorse-workflow-executor/deeplang/src/it/scala/ai/deepsense/deeplang/DeeplangIntegTestSupport.scala
@@ -21,7 +21,7 @@ import scala.reflect.ClassTag
 import scala.reflect.runtime.universe.TypeTag
 
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.Row
+import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types._
 import org.apache.spark.{SparkConf, SparkContext}
 import org.scalatest.BeforeAndAfterAll
@@ -32,6 +32,7 @@ import ai.deepsense.deeplang.OperationExecutionDispatcher.Result
 import ai.deepsense.deeplang.doperables.dataframe.DataFrame
 import ai.deepsense.deeplang.utils.DataFrameMatchers
 import ai.deepsense.sparkutils.SparkSQLSession
+import ai.deepsense.sparkutils.spi.SparkSessionInitializer
 
 /**
  * Adds features to facilitate integration testing using Spark
@@ -54,6 +55,12 @@ trait DeeplangIntegTestSupport extends UnitSpec with BeforeAndAfterAll with Loca
 
 object DeeplangIntegTestSupport extends UnitSpec with DataFrameMatchers {
 
+}
+
+class TestUDFRegistrator extends SparkSessionInitializer {
+  val myOp = (d: Double) => d.toInt
+  override def init(sparkSession: SparkSession): Unit =
+    sparkSession.udf.register("myOp", myOp)
 }
 
 private class MockedCodeExecutor extends CustomCodeExecutor {

--- a/seahorse-workflow-executor/deeplang/src/it/scala/ai/deepsense/deeplang/LocalExecutionContext.scala
+++ b/seahorse-workflow-executor/deeplang/src/it/scala/ai/deepsense/deeplang/LocalExecutionContext.scala
@@ -91,7 +91,6 @@ object LocalExecutionContext {
   lazy val sparkContext: SparkContext = new SparkContext(sparkConf)
   lazy val sparkSQLSession: SparkSQLSession = {
     val sqlSession = new SparkSQLSession(sparkContext)
-    UserDefinedFunctions.registerFunctions(sqlSession.udfRegistration)
     sqlSession
   }
 

--- a/seahorse-workflow-executor/deeplang/src/it/scala/ai/deepsense/deeplang/StandaloneSparkClusterForTests.scala
+++ b/seahorse-workflow-executor/deeplang/src/it/scala/ai/deepsense/deeplang/StandaloneSparkClusterForTests.scala
@@ -106,8 +106,6 @@ object StandaloneSparkClusterForTests {
     sparkContext.hadoopConfiguration.set("parquet.enable.summary-metadata", "false")
     val sparkSQLSession = new SparkSQLSession(sparkContext)
 
-    UserDefinedFunctions.registerFunctions(sparkSQLSession.udfRegistration)
-
     val inferContext = MockedInferContext(
       dataFrameBuilder = DataFrameBuilder(sparkSQLSession)
     )

--- a/seahorse-workflow-executor/deeplang/src/main/scala/ai/deepsense/deeplang/inference/SqlSchemaInferrer.scala
+++ b/seahorse-workflow-executor/deeplang/src/main/scala/ai/deepsense/deeplang/inference/SqlSchemaInferrer.scala
@@ -30,7 +30,6 @@ class SqlSchemaInferrer {
   : (StructType, InferenceWarnings) = {
     try {
     val localSpark = SQL.createEmptySparkSQLSession()
-      UserDefinedFunctions.registerFunctions(localSpark.udfRegistration)
       inputSchemas.foreach { case (dataFrameId, schema) =>
         val emptyData = localSpark.sparkContext.parallelize(Seq(Row.empty))
         val emptyDf = localSpark.createDataFrame(emptyData, schema)

--- a/seahorse-workflow-executor/scalastyle-config.xml
+++ b/seahorse-workflow-executor/scalastyle-config.xml
@@ -22,6 +22,33 @@
     <parameters>
       <parameter name="regex">true</parameter>
       <parameter name="header"><![CDATA[/\*\*
+ \* Copyright 201[56789] .*
+ \*
+ \* Licensed under the Apache License, Version 2.0 \(the \"License\"\);
+ \* you may not use this file except in compliance with the License\.
+ \* You may obtain a copy of the License at
+ \*
+ \*     http:\/\/www.apache.org\/licenses\/LICENSE-2.0
+ \*
+ \* Unless required by applicable law or agreed to in writing\, software
+ \* distributed under the License is distributed on an \"AS IS\" BASIS\,
+ \* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND\, either express or implied\.
+ \* See the License for the specific language governing permissions and
+ \* limitations under the License\.(?:
+ \*
+ \* .*(?:(?:
+ \* .*)|(?:
+ \*))*)?
+ \*/\n?
+]]></parameter>
+    </parameters>
+  </check>
+
+  <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
+    <customMessage>Apache License with third-party copyright in use.</customMessage>
+    <parameters>
+      <parameter name="regex">true</parameter>
+      <parameter name="header"><![CDATA[/\*\*
  \* Copyright 201[56789] deepsense.ai \(CodiLime, Inc\)
  \*
  \* Licensed under the Apache License, Version 2.0 \(the \"License\"\);

--- a/seahorse-workflow-executor/sparkutils2.x/src/main/scala/ai/deepsense/sparkutils/SparkUtils.scala
+++ b/seahorse-workflow-executor/sparkutils2.x/src/main/scala/ai/deepsense/sparkutils/SparkUtils.scala
@@ -18,6 +18,7 @@ package ai.deepsense.sparkutils
 
 
 import scala.concurrent.{Await, Future}
+import ai.deepsense.sparkutils.spi.SparkSessionInitializer
 import scala.concurrent.duration.Duration
 import scala.reflect.ClassTag
 import scala.reflect.api.Symbols
@@ -39,6 +40,9 @@ import org.apache.spark.{SparkContext, ml}
 class SparkSQLSession private[sparkutils](val sparkSession: SparkSession) {
   def this(sparkContext: SparkContext) = this(SparkSession.builder().config(sparkContext.getConf).getOrCreate())
 
+  // Calls SPI to allow registered clients to inject UDFs other global session state.
+  SparkSessionInitializer(sparkSession)
+
   def sparkContext: SparkContext = sparkSession.sparkContext
 
   def createDataFrame(rdd: RDD[Row], schema: StructType): DataFrame = sparkSession.createDataFrame(rdd, schema)
@@ -59,7 +63,7 @@ class SparkSQLSession private[sparkutils](val sparkSession: SparkSession) {
 
   def newSession(): SparkSQLSession = new SparkSQLSession(sparkSession.newSession())
 
-  // This is for pyexecutor.py
+  // This is for pyexecutor.py and DOperables and SparkSessionInitializer
   def getSparkSession = sparkSession
 }
 

--- a/seahorse-workflow-executor/sparkutils2.x/src/main/scala/ai/deepsense/sparkutils/spi/SparkSessionInitializer.scala
+++ b/seahorse-workflow-executor/sparkutils2.x/src/main/scala/ai/deepsense/sparkutils/spi/SparkSessionInitializer.scala
@@ -1,19 +1,17 @@
-/*
- * This software is licensed under the Apache 2 license, quoted below.
+/**
+ * Copyright 2018 Astraea, Inc.
  *
- * Copyright 2018 Astraea. Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package ai.deepsense.sparkutils.spi

--- a/seahorse-workflow-executor/sparkutils2.x/src/main/scala/ai/deepsense/sparkutils/spi/SparkSessionInitializer.scala
+++ b/seahorse-workflow-executor/sparkutils2.x/src/main/scala/ai/deepsense/sparkutils/spi/SparkSessionInitializer.scala
@@ -1,0 +1,45 @@
+/*
+ * This software is licensed under the Apache 2 license, quoted below.
+ *
+ * Copyright 2018 Astraea. Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package ai.deepsense.sparkutils.spi
+
+import java.util.ServiceLoader
+
+import org.apache.spark.sql.SparkSession
+import scala.collection.JavaConversions._
+
+/**
+  * SPI Interface for services wishing to tweak the SparkSession after its created
+  * (e.g. for registering UDFs).
+  *
+  * @since 5/22/18
+  */
+trait SparkSessionInitializer {
+  def init(sparkSession: SparkSession): Unit
+}
+
+object SparkSessionInitializer {
+  def apply(sparkSession: SparkSession): SparkSession = {
+
+    val initializers = ServiceLoader.load(classOf[SparkSessionInitializer])
+    for(initter <- initializers) {
+      initter.init(sparkSession)
+    }
+    sparkSession
+  }
+}

--- a/seahorse-workflow-executor/workflowexecutor/src/main/scala/ai/deepsense/workflowexecutor/executor/Executor.scala
+++ b/seahorse-workflow-executor/workflowexecutor/src/main/scala/ai/deepsense/workflowexecutor/executor/Executor.scala
@@ -91,7 +91,6 @@ trait Executor extends Logging {
 
   def createSparkSQLSession(sparkContext: SparkContext): SparkSQLSession = {
     val sparkSQLSession = new SparkSQLSession(sparkContext)
-    UserDefinedFunctions.registerFunctions(sparkSQLSession.udfRegistration)
     sparkSQLSession
   }
 


### PR DESCRIPTION
As evidenced by the new test in `SqlTransformationIntegSpec`, registration of UDFs and (other session state changes) are not able to be applied to creation of new `SparkSession`s in a consistent or accessible manner, neither within the system nor by API users. This PR creates an SPI whereby API/plugin developers can register UDFs and Rewrite Rules such that they are applied consistently throughout Seahorse whenever a new SparkSession is created. The most common use case is to allow SQL transforms to call registered UDFs.

